### PR TITLE
refactor: Rename output security_group to default_security_group

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AWS VPC module to create a basic VPCs with 1 public subnet in AWS.
 ### Outputs
 * `vpc_id`: String 
 * `subnet_id`: String
-* `security_group`: String
+* `default_security_group`: String
 
 ### Example
 ```hcl

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,6 @@ output "subnet_id" {
   value = "${aws_subnet.s.id}"
 }
 
-output "security_group" {
+output "default_security_group" {
   value = "${aws_default_security_group.d.id}"
 }

--- a/test/fixtures/wrapper/test.tf
+++ b/test/fixtures/wrapper/test.tf
@@ -34,7 +34,7 @@ resource "aws_instance" "i" {
   subnet_id     = "${module.vpc.subnet_id}"
   key_name      = "${aws_key_pair.k.key_name}"
 
-  vpc_security_group_ids = ["${module.vpc.security_group}"]
+  vpc_security_group_ids = ["${module.vpc.default_security_group}"]
 
   tags {
     Name = "${local.name_prefix}instance"


### PR DESCRIPTION
Rename output security_group to default_security_group as its the VPC
default security group.