### PR TITLE
feat: Move from 1 subnets to 1 public per AZs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # VPC Module
 
-AWS VPC module to create a basic VPCs with 1 public subnet in AWS.
+AWS VPC module to create a basic VPCs with 1 public subnet per AZ in AWS.
 
 ## How To Use
 
@@ -10,8 +10,9 @@ AWS VPC module to create a basic VPCs with 1 public subnet in AWS.
 
 ### Outputs
 * `vpc_id`: String 
-* `subnet_id`: String
 * `default_security_group`: String
+* `subnets`: Map[List]: List of subnet ids per tier (_public_)
+* `cidr_blocks`: Map[List]: List of CIDR blocks per tier (_vpc_, _public_)
 
 ### Example
 ```hcl

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,10 +2,19 @@ output "vpc_id" {
   value = "${aws_vpc.v.id}"
 }
 
-output "subnet_id" {
-  value = "${aws_subnet.s.id}"
-}
-
 output "default_security_group" {
   value = "${aws_default_security_group.d.id}"
+}
+
+output "subnets" {
+  value = {
+    public = ["${aws_subnet.public.*.id}"]
+  }
+}
+
+output "cidr_blocks" {
+  value = {
+    vpc    = ["${aws_vpc.v.cidr_block}"]
+    public = ["${aws_subnet.public.*.cidr_block}"]
+  }
 }

--- a/subnets.tf
+++ b/subnets.tf
@@ -1,0 +1,13 @@
+data "aws_availability_zones" "available" {}
+
+resource "aws_subnet" "public" {
+  count = "${length(data.aws_availability_zones.available.names)}"
+
+  vpc_id            = "${aws_vpc.v.id}"
+  availability_zone = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  # 3 new bits mean 8 subnets (should be enough as regions have maximum 6 AZs)
+  cidr_block = "${cidrsubnet(aws_vpc.v.cidr_block, 3, count.index)}"
+
+  map_public_ip_on_launch = true
+}

--- a/test/fixtures/wrapper/test.tf
+++ b/test/fixtures/wrapper/test.tf
@@ -28,10 +28,15 @@ resource "aws_key_pair" "k" {
   public_key      = "${file("~/.ssh/id_rsa.pub")}"
 }
 
+resource "random_integer" "az" {
+  min = 0
+  max = "${length(module.vpc.subnets["public"]) - 1}" # -1 as the max value is inclusive
+}
+
 resource "aws_instance" "i" {
   instance_type = "t2.micro"
   ami           = "${data.aws_ami.core.id}"
-  subnet_id     = "${module.vpc.subnet_id}"
+  subnet_id     = "${element(module.vpc.subnets["public"], random_integer.az.result)}"
   key_name      = "${aws_key_pair.k.key_name}"
 
   vpc_security_group_ids = ["${module.vpc.default_security_group}"]

--- a/vpc.tf
+++ b/vpc.tf
@@ -6,13 +6,6 @@ resource "aws_internet_gateway" "i" {
   vpc_id = "${aws_vpc.v.id}"
 }
 
-resource "aws_subnet" "s" {
-  vpc_id     = "${aws_vpc.v.id}"
-  cidr_block = "${aws_vpc.v.cidr_block}"
-
-  map_public_ip_on_launch = true
-}
-
 resource "aws_default_route_table" "r" {
   default_route_table_id = "${aws_vpc.v.main_route_table_id}"
 


### PR DESCRIPTION
Update the module to spread the VPC on all AZs from the region. Only one
public subnets will be created per AZs (for now).

* Update to have several subnets.
* Update outpus to expose subnets IDs and CIDR blocks.
* Use cidrsubnet to define blocks (from VPC block).