### PR TITLE
fix: Get bastion ip from terraform outputs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@
 ruby '2.4.2'
 
 source 'https://rubygems.org/' do
-  gem 'kitchen-terraform', "~> 4.1"
+  gem "kitchen-terraform", git: "https://github.com/gbergere/kitchen-terraform.git", branch: "feat/bastion-host-from-terraform-output"
 end

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -23,24 +23,7 @@ platforms:
             - operating_system
           hosts_output: instance_ip
           user: core
-          # @TODO Clean when this issue is fixed : https://github.com/newcontext-oss/kitchen-terraform/issues/301
-          bastion_host: "<%= `terraform output -state=test/fixtures/wrapper/terraform.tfstate.d/kitchen-terraform-default-case-1/terraform.tfstate bastion_ip || echo 1` %>"
-          bastion_user: core
-  - name: case_2
-    driver:
-      variables:
-        price_saving_enabled: "0"
-    verifier:
-      systems:
-        - name: remote
-          backend: ssh
-          controls:
-            - internet_access
-            - operating_system
-          hosts_output: instance_ip
-          user: core
-          # @TODO Clean when this issue is fixed : https://github.com/newcontext-oss/kitchen-terraform/issues/301
-          bastion_host: "<%= `terraform output -state=test/fixtures/wrapper/terraform.tfstate.d/kitchen-terraform-default-case-2/terraform.tfstate bastion_ip || echo 1` %>"
+          bastion_host_output: bastion_ip
           bastion_user: core
 
 suites:


### PR DESCRIPTION
Remove workaround to get bastion ip from terraform outputs to use
proper feature.